### PR TITLE
reprepare for testing

### DIFF
--- a/packages/nouns-contracts/contracts/SZNounsAuctionHouse.sol
+++ b/packages/nouns-contracts/contracts/SZNounsAuctionHouse.sol
@@ -40,32 +40,35 @@ contract SZNounsAuctionHouse is NounsAuctionHouse {
         FALL
     }
 
-    uint256 constant DEFAULT_WINTER_DURATION = 24 hours;
-    uint256 constant DEFAULT_FALL_SPRING_DURATION = 12 hours;
-    uint256 constant DEFAULT_SUMMER_DURATION = 6 hours;
+    // TODO: revisit this from here
+    uint256 constant DEFAULT_WINTER_DURATION = 3 minutes;
+    uint256 constant DEFAULT_FALL_SPRING_DURATION = 2 minutes;
+    uint256 constant DEFAULT_SUMMER_DURATION = 1 minutes;
 
     // Length of 4, indices corresponding to int cast of enum value.
     uint256[4] durations;
 
     function getSzn() public view returns (SZN) {
-        uint256 month = BokkyPooBahsDateTimeLibrary.getMonth(block.timestamp);
-
-        // evenly distributing seasons throughout the calendar year
-        if (month < 3) {
-            return SZN.WINTER;
-        }
-        if (month < 6) {
-            return SZN.SPRING;
-        }
-        if (month < 9) {
-            return SZN.SUMMER;
-        }
-        if (month < 12) {
-            return SZN.FALL;
-        }
-        // December is winter.
-        return SZN.WINTER;
+        uint256 minute = BokkyPooBahsDateTimeLibrary.getMinute(block.timestamp);
+        // Before March is winter.
+        if (minute % 8 < 2) {
+           return SZN.WINTER;
+       }
+       // After March and before May is Spring.
+       if (minute % 8 < 4) {
+           return SZN.SPRING;
+       }
+       // After May and before August is Summer.
+       if (minute % 8 < 6) {
+           return SZN.SUMMER;
+       }
+       // After August and before December is Fall.
+       // TODO(szns) fall is currently 4 minutes, should one of those minutes be SPRING?
+       if (minute % 8 < 8) {
+           return SZN.FALL;
+       }
     }
+    // TODO: to here
 
     function getSznDuration(SZN szn) public view returns (uint256) {
         uint256 duration = durations[uint256(szn)];

--- a/packages/nouns-contracts/contracts/SZNounsToken.sol
+++ b/packages/nouns-contracts/contracts/SZNounsToken.sol
@@ -76,7 +76,7 @@ contract SZNounsToken is NounsToken {
      */
     function mint() public override onlyMinter returns (uint256) {
         // 4121 is the total number of sznouns minted across first 5 years
-        if (_currentNounId <= 4121 && _currentNounId % 20 == 0) {
+        if (_currentNounId <= 4121 && _currentNounId % 3 == 0) { // TODO: revisit this
             _mintTo(sznoundersDAO, _currentNounId++);
             _mintTo(nounsDAO, _currentNounId++);
         }

--- a/packages/nouns-contracts/contracts/governance/NounsDAOExecutor.sol
+++ b/packages/nouns-contracts/contracts/governance/NounsDAOExecutor.sol
@@ -60,7 +60,7 @@ contract NounsDAOExecutor {
     );
 
     uint256 public constant GRACE_PERIOD = 14 days;
-    uint256 public constant MINIMUM_DELAY = 2 days;
+    uint256 public constant MINIMUM_DELAY = 1 seconds; // TODO: revisit this
     uint256 public constant MAXIMUM_DELAY = 30 days;
 
     address public admin;

--- a/packages/nouns-contracts/contracts/governance/NounsDAOLogicV1.sol
+++ b/packages/nouns-contracts/contracts/governance/NounsDAOLogicV1.sol
@@ -73,7 +73,7 @@ contract NounsDAOLogicV1 is NounsDAOStorageV1, NounsDAOEvents {
     uint256 public constant MAX_PROPOSAL_THRESHOLD_BPS = 1_000; // 1,000 basis points or 10%
 
     /// @notice The minimum setable voting period
-    uint256 public constant MIN_VOTING_PERIOD = 5_760; // About 24 hours
+    uint256 public constant MIN_VOTING_PERIOD = 1; // TODO(szns): revert this. 1 block min vote period
 
     /// @notice The max setable voting period
     uint256 public constant MAX_VOTING_PERIOD = 80_640; // About 2 weeks

--- a/packages/nouns-contracts/tasks/deploy.ts
+++ b/packages/nouns-contracts/tasks/deploy.ts
@@ -30,8 +30,8 @@ task('deploy', 'Deploys NFTDescriptor, NounsDescriptor, NounsSeeder, and NounsTo
   .addOptionalParam(
     'auctionTimeBuffer',
     'The auction time buffer (seconds)',
-    5 * 60 /* 5 minutes */, // confirmed
-    // 30 /* 30 sec temp for testing*/,
+    // 5 * 60 /* 5 minutes */, // confirmed
+    30 /* 30 sec temp for testing*/,
     types.int,
   )
   .addOptionalParam(
@@ -49,31 +49,31 @@ task('deploy', 'Deploys NFTDescriptor, NounsDescriptor, NounsSeeder, and NounsTo
   .addOptionalParam(
     'auctionDuration', // this is going to be subject to enforcement at the auction house contract level anyways
     'The auction duration (seconds)',
-    60 * 5 /* 5 minutes */, // confirmed
-    // 60 * 1 /* 1 minute */,
+    // 60 * 5 /* 5 minutes */, // confirmed
+    60 * 1 /* 1 minute */,
     types.int,
   )
   .addOptionalParam(
     'timelockDelay',
     'The timelock delay (seconds)',
-    60 * 60 * 24 * 2 /* 2 days */, // confirmed
-    // 60 * 5 /* 5 minutes temp for testing */,
+    // 60 * 60 * 24 * 2 /* 2 days */, // confirmed
+    60 * 3 /* 3 minutes temp for testing */,
     types.int,
   )
   .addOptionalParam(
     'votingPeriod',
     'The voting period (blocks)',
     // Math.round(4 * 60 * 24 * (60 / 13)) /* 4 days (13s blocks) */, // the default, not used
-    Math.round(3 * 60 * 24 * (60 / 13)) /* 3 days (13s blocks) */, // confirmed
-    // Math.round(5 * (60 / 13)) /* 5 minutes temp for testing */,
+    // Math.round(3 * 60 * 24 * (60 / 13)) /* 3 days (13s blocks) */, // confirmed
+    Math.round(3 * (60 / 13)) /* 3 minutes temp for testing */,
     types.int,
   )
   .addOptionalParam(
     'votingDelay',
     'The voting delay (blocks)',
     // Math.round(3 * 60 * 24 * (60 / 13)) /* 3 days (13s blocks) */, // the default, not used
-    Math.round(2 * 60 * 24 * (60 / 13)) /* 2 days (13s blocks) */, // confirmed
-    // Math.round(5 * (60 / 13)) /* 5 minutes temp for testing */,
+    // Math.round(2 * 60 * 24 * (60 / 13)) /* 2 days (13s blocks) */, // confirmed
+    Math.round(5 * (60 / 13)) /* 3 minutes temp for testing */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-sdk/src/contract/addresses.json
+++ b/packages/nouns-sdk/src/contract/addresses.json
@@ -14,18 +14,18 @@
     "nounsDAOLogicV1": "0x8b9a95793Ad1B6b6ABDD15b458D9f0Ba1bfdD3fc"
   },
   "4": {
-    "nounsToken": "0xBb7A2237c080a6bc6F7Dd2A66dB87a304Fcda9dC",
-    "SZNounsToken": "0xBb7A2237c080a6bc6F7Dd2A66dB87a304Fcda9dC",
-    "nounsSeeder": "0xA98A1b1Cc4f5746A753167BAf8e0C26AcBe42F2E",
-    "nounsDescriptor": "0x78c132b13B60EdfD170F809591C6C95119470fa2",
-    "nftDescriptor": "0x2834006C846282542dA5406e4785FD8FAB3B7AB1",
-    "nounsAuctionHouse": "0x353663b173B7ee442706954B7948091C38ceE885",
-    "SZNounsAuctionHouse": "0x353663b173B7ee442706954B7948091C38ceE885",
-    "nounsAuctionHouseProxy": "0x1D3e839B046E5BcBAa4Dd209923BcBde6c290eB7",
-    "nounsAuctionHouseProxyAdmin": "0x697bc413854da6C5E86F51B0DbCfddB8166984c3",
-    "nounsDaoExecutor": "0x789848e7614F7596Db69658ee661ffcef9F52780",
-    "nounsDAOProxy": "0x5054488fB27853c5C4DAee65425aDdaC4ee75406",
-    "nounsDAOLogicV1": "0x1a6e43bDD63E0fD7A4F0DE7C7C9ac8D68dEd3462"
+    "nounsToken": "0x341c6642a05f0D4ECf6b33eF5343c3Ac2c826381",
+    "SZNounsToken": "0x341c6642a05f0D4ECf6b33eF5343c3Ac2c826381",
+    "nounsSeeder": "0xCC8a0FB5ab3C7132c1b2A0109142Fb112c4Ce515",
+    "nounsDescriptor": "0x53fa29763EBFa4C504a1222F7798676c5Bad1Dd1",
+    "nftDescriptor": "0x28a2022CC639b69244eF3B540c0F3D73Ae5208b7",
+    "nounsAuctionHouse": "0x3812C3a20d65bc40b1de322584d45e92002f6105",
+    "SZNounsAuctionHouse": "0x3812C3a20d65bc40b1de322584d45e92002f6105",
+    "nounsAuctionHouseProxy": "0xb379888A276d66351aaE75ada54d2100256c65cd",
+    "nounsAuctionHouseProxyAdmin": "0xe62f0f263e19C75cDeaF83FDc2b52D79A51aBc1c",
+    "nounsDaoExecutor": "0x2c2C5aE2C37d19F793ece49138D0d1802fA427b4",
+    "nounsDAOProxy": "0x820132e123f5178998B05DA087FfB1aae249aB17",
+    "nounsDAOLogicV1": "0x79c7c4d3e81F340e26f092FF18d8386E23A117bb"
   },
   "31337": {
     "nounsToken": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",

--- a/packages/nouns-subgraph/config/rinkeby-fork.json
+++ b/packages/nouns-subgraph/config/rinkeby-fork.json
@@ -1,15 +1,15 @@
 {
   "network": "rinkeby",
   "nounsToken": {
-    "address": "0xBb7A2237c080a6bc6F7Dd2A66dB87a304Fcda9dC",
-    "startBlock": 10863400
+    "address": "0x341c6642a05f0D4ECf6b33eF5343c3Ac2c826381",
+    "startBlock": 11201031
   },
   "nounsAuctionHouse": {
-    "address": "0x1D3e839B046E5BcBAa4Dd209923BcBde6c290eB7",
-    "startBlock": 10863400
+    "address": "0xb379888A276d66351aaE75ada54d2100256c65cd",
+    "startBlock": 11201031
   },
   "nounsDAO": {
-    "address": "0x5054488fB27853c5C4DAee65425aDdaC4ee75406",
-    "startBlock": 10863400
+    "address": "0x820132e123f5178998B05DA087FfB1aae249aB17",
+    "startBlock": 11201031
   }
 }

--- a/packages/nouns-subgraph/subgraph.yaml
+++ b/packages/nouns-subgraph/subgraph.yaml
@@ -6,11 +6,11 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: NounsAuctionHouse
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xBDAe19BcA243eb440D900f10e310b8d69C736364'
+      address: '0xb379888A276d66351aaE75ada54d2100256c65cd'
       abi: NounsAuctionHouse
-      startBlock: 14980800
+      startBlock: 11201031
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -35,11 +35,11 @@ dataSources:
           handler: handleAuctionSettled
   - kind: ethereum/contract
     name: NounsToken
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0xD6c4cB5A3e040abC8bE977dC10B658Ec9072a1F4'
+      address: '0x341c6642a05f0D4ECf6b33eF5343c3Ac2c826381'
       abi: NounsToken
-      startBlock: 14980800
+      startBlock: 11201031
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
@@ -65,11 +65,11 @@ dataSources:
           handler: handleTransfer
   - kind: ethereum/contract
     name: NounsDAO
-    network: mainnet
+    network: rinkeby
     source:
-      address: '0x67CeD26a6435A2F12b52B7216E26BA43af02eCFF'
+      address: '0x820132e123f5178998B05DA087FfB1aae249aB17'
       abi: NounsDAO
-      startBlock: 14980800
+      startBlock: 11201031
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4

--- a/packages/nouns-webapp/src/utils/nounderNoun.ts
+++ b/packages/nouns-webapp/src/utils/nounderNoun.ts
@@ -3,7 +3,7 @@ import { AuctionState } from '../state/slices/auction';
 import { BigNumber } from '@ethersproject/bignumber';
 
 export const isNounderNoun = (nounId: BigNumber) => {
-  return nounId.mod(20).eq(0) || nounId.eq(0);
+  return nounId.mod(3).eq(0) || nounId.eq(0); // TODO: revisit this
 };
 
 const emptyNounderAuction = (onDisplayAuctionId: number): Auction => {

--- a/packages/nouns-webapp/src/utils/nounsDAONoun.ts
+++ b/packages/nouns-webapp/src/utils/nounsDAONoun.ts
@@ -3,7 +3,7 @@ import { AuctionState } from '../state/slices/auction';
 import { BigNumber } from '@ethersproject/bignumber';
 
 export const isNounsDAONoun = (nounId: BigNumber) => {
-  return nounId.mod(20).eq(1) || nounId.eq(1);
+  return nounId.mod(3).eq(1) || nounId.eq(1); // TODO: revisit this
 };
 
 const emptyNounsDAOAuction = (onDisplayAuctionId: number): Auction => {


### PR DESCRIPTION
essentially reverting some of the productionizing changes introduced in https://github.com/sznounsDAO/sznouns/pull/41 and https://github.com/sznounsDAO/sznouns/pull/43

Subgraph in `nouns-webapp/src/config.ts` remains `https://thegraph.com/hosted-service/subgraph/0xgoretex/sznouns-omni2`